### PR TITLE
Refactor operation building

### DIFF
--- a/lib/notion_rb.rb
+++ b/lib/notion_rb.rb
@@ -20,8 +20,10 @@ require 'notion_rb/utils/uuid_validator'
 
 require 'notion_rb/block'
 
+require 'notion_rb/transaction'
 require 'notion_rb/operations/commands/factory'
 require 'notion_rb/operations/factory'
+
 module NotionRb
   def self.config
     @config ||= {}

--- a/lib/notion_rb.rb
+++ b/lib/notion_rb.rb
@@ -21,6 +21,7 @@ require 'notion_rb/utils/uuid_validator'
 require 'notion_rb/block'
 
 require 'notion_rb/operations/commands/factory'
+require 'notion_rb/operations/factory'
 module NotionRb
   def self.config
     @config ||= {}

--- a/lib/notion_rb.rb
+++ b/lib/notion_rb.rb
@@ -20,6 +20,7 @@ require 'notion_rb/utils/uuid_validator'
 
 require 'notion_rb/block'
 
+require 'notion_rb/operations/commands/factory'
 module NotionRb
   def self.config
     @config ||= {}

--- a/lib/notion_rb.rb
+++ b/lib/notion_rb.rb
@@ -24,6 +24,8 @@ require 'notion_rb/transaction'
 require 'notion_rb/operations/commands/factory'
 require 'notion_rb/operations/factory'
 
+require 'notion_rb/request_params'
+
 module NotionRb
   def self.config
     @config ||= {}

--- a/lib/notion_rb/api/create.rb
+++ b/lib/notion_rb/api/create.rb
@@ -22,52 +22,15 @@ module NotionRb
       end
 
       def params
-        {
-          requestId: SecureRandom.uuid,
-          transactions: [{
-            id: SecureRandom.uuid,
-            operations: [{
-              id: @notion_id,
-              table: 'block',
-              path: [],
-              command: 'set',
-              args: { type: 'text', id: @notion_id, version: 1 }
-            }, {
-              id: @notion_id,
-              table: 'block',
-              path: [],
-              command: 'update',
-              args: { parent_id: @parent_id, parent_table: 'block', alive: true }
-            }, {
-              id: @parent_id,
-              table: 'block',
-              path: ['content'],
-              command: 'listAfter',
-              args: { id: @notion_id }
-            }, {
-              id: @notion_id,
-              table: 'block',
-              path: %w[
-                properties
-                title
-              ],
-              command: 'set',
-              args: []
-            }, {
-              id: @notion_id,
-              table: 'block',
-              path: ['created_time'],
-              command: 'set',
-              args: @created_at
-            }, {
-              id: @notion_id,
-              table: 'block',
-              path: ['last_edited_time'],
-              command: 'set',
-              args: @created_at
-            }]
-          }]
-        }
+        NotionRb::RequestParams.new.add_transaction.tap do |transaction|
+          transaction
+            .add_operation(:set_block_type, @notion_id, 'block')
+            .add_operation(:update_parent, @notion_id, @parent_id)
+            .add_operation(:list_after, @parent_id, @notion_id)
+            .add_operation(:set_block_title, @notion_id, [])
+            .add_operation(:set_block_created_time, @notion_id, @created_at)
+            .add_operation(:set_block_last_edited_time, @notion_id, @created_at)
+        end.to_h
       end
     end
   end

--- a/lib/notion_rb/operations/commands/base.rb
+++ b/lib/notion_rb/operations/commands/base.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module NotionRb
+  module Operations
+    module Commands
+      class Base
+        attr_reader :id, :command, :table, :args, :path
+
+        def initialize(id, opts = {})
+          @id = id
+          @command = opts.fetch(:command) do
+            raise ArgumentError, 'Commands must specify command action key'
+          end
+          @table = opts[:table]
+          @args = opts[:args]
+          @path = opts.fetch(:path, [])
+        end
+
+        def to_h
+          {
+            id: id,
+            table: table,
+            path: path,
+            command: command,
+            args: args
+          }
+        end
+      end
+    end
+  end
+end

--- a/lib/notion_rb/operations/commands/factory.rb
+++ b/lib/notion_rb/operations/commands/factory.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require_relative './base'
+module NotionRb
+  module Operations
+    module Commands
+      COMMANDS = Hash[
+      ]
+
+      class Factory
+        def self.build(command_name, id, opts = {})
+          COMMANDS.fetch(command_name).new(
+            id,
+            opts
+          )
+        end
+      end
+    end
+  end
+end

--- a/lib/notion_rb/operations/commands/factory.rb
+++ b/lib/notion_rb/operations/commands/factory.rb
@@ -1,14 +1,18 @@
 # frozen_string_literal: true
 
 require_relative './base'
+require_relative './list_after'
 require_relative './set'
+require_relative './update'
 
 module NotionRb
   module Operations
     module Commands
       COMMANDS = Hash[
         [
-          Set
+          ListAfter,
+          Set,
+          Update
         ].map { |klass| [klass::NAME, klass] }
       ]
 

--- a/lib/notion_rb/operations/commands/factory.rb
+++ b/lib/notion_rb/operations/commands/factory.rb
@@ -1,10 +1,15 @@
 # frozen_string_literal: true
 
 require_relative './base'
+require_relative './set'
+
 module NotionRb
   module Operations
     module Commands
       COMMANDS = Hash[
+        [
+          Set
+        ].map { |klass| [klass::NAME, klass] }
       ]
 
       class Factory

--- a/lib/notion_rb/operations/commands/list_after.rb
+++ b/lib/notion_rb/operations/commands/list_after.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module NotionRb
+  module Operations
+    module Commands
+      class ListAfter < Base
+        COMMAND = 'listAfter'
+        NAME = :list_after
+
+        def initialize(id, opts = {})
+          opts.merge!(command: COMMAND)
+          super
+        end
+      end
+    end
+  end
+end

--- a/lib/notion_rb/operations/commands/set.rb
+++ b/lib/notion_rb/operations/commands/set.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module NotionRb
+  module Operations
+    module Commands
+      class Set < Base
+        COMMAND = 'set'
+        NAME = :set
+
+        def initialize(id, opts = {})
+          opts.merge!(command: COMMAND)
+          super
+        end
+      end
+    end
+  end
+end

--- a/lib/notion_rb/operations/commands/update.rb
+++ b/lib/notion_rb/operations/commands/update.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module NotionRb
+  module Operations
+    module Commands
+      class Update < Base
+        COMMAND = 'update'
+        NAME = :update
+
+        def initialize(id, opts = {})
+          opts.merge!(command: COMMAND)
+          super
+        end
+      end
+    end
+  end
+end

--- a/lib/notion_rb/operations/factory.rb
+++ b/lib/notion_rb/operations/factory.rb
@@ -3,6 +3,7 @@
 require_relative './set_block_type'
 require_relative './set_block_last_edited_time'
 require_relative './set_block_created_time'
+require_relative './set_block_title'
 require_relative './list_after'
 module NotionRb
   module Operations
@@ -12,6 +13,7 @@ module NotionRb
           ListAfter,
           SetBlockCreatedTime,
           SetBlockLastEditedTime,
+          SetBlockTitle,
           SetBlockType
         ].map { |klass| [klass::OPERATION_NAME, klass] }
       ]

--- a/lib/notion_rb/operations/factory.rb
+++ b/lib/notion_rb/operations/factory.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require_relative './set_block_type'
-
+require_relative './set_block_last_edited_time'
 require_relative './list_after'
 module NotionRb
   module Operations
@@ -9,6 +9,7 @@ module NotionRb
       OPERATIONS = Hash[
         [
           ListAfter,
+          SetBlockLastEditedTime,
           SetBlockType
         ].map { |klass| [klass::OPERATION_NAME, klass] }
       ]

--- a/lib/notion_rb/operations/factory.rb
+++ b/lib/notion_rb/operations/factory.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require_relative './set_block_type'
+
+module NotionRb
+  module Operations
+    class Factory
+      OPERATIONS = Hash[
+        [
+          SetBlockType
+        ].map { |klass| [klass::OPERATION_NAME, klass] }
+      ]
+
+      def self.build(operation_name, *args)
+        OPERATIONS.fetch(operation_name).new(
+          *args
+        )
+      end
+    end
+  end
+end

--- a/lib/notion_rb/operations/factory.rb
+++ b/lib/notion_rb/operations/factory.rb
@@ -5,6 +5,8 @@ require_relative './set_block_last_edited_time'
 require_relative './set_block_created_time'
 require_relative './set_block_title'
 require_relative './list_after'
+require_relative './update_parent'
+
 module NotionRb
   module Operations
     class Factory
@@ -14,7 +16,8 @@ module NotionRb
           SetBlockCreatedTime,
           SetBlockLastEditedTime,
           SetBlockTitle,
-          SetBlockType
+          SetBlockType,
+          UpdateParent
         ].map { |klass| [klass::OPERATION_NAME, klass] }
       ]
 

--- a/lib/notion_rb/operations/factory.rb
+++ b/lib/notion_rb/operations/factory.rb
@@ -2,11 +2,13 @@
 
 require_relative './set_block_type'
 
+require_relative './list_after'
 module NotionRb
   module Operations
     class Factory
       OPERATIONS = Hash[
         [
+          ListAfter,
           SetBlockType
         ].map { |klass| [klass::OPERATION_NAME, klass] }
       ]

--- a/lib/notion_rb/operations/factory.rb
+++ b/lib/notion_rb/operations/factory.rb
@@ -2,6 +2,7 @@
 
 require_relative './set_block_type'
 require_relative './set_block_last_edited_time'
+require_relative './set_block_created_time'
 require_relative './list_after'
 module NotionRb
   module Operations
@@ -9,6 +10,7 @@ module NotionRb
       OPERATIONS = Hash[
         [
           ListAfter,
+          SetBlockCreatedTime,
           SetBlockLastEditedTime,
           SetBlockType
         ].map { |klass| [klass::OPERATION_NAME, klass] }

--- a/lib/notion_rb/operations/list_after.rb
+++ b/lib/notion_rb/operations/list_after.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module NotionRb
+  module Operations
+    class ListAfter
+      COMMAND_TYPE = :list_after
+      OPERATION_NAME = :list_after
+      DEFAULT_TABLE = 'block'
+      DEFAULT_PATH = ['content']
+
+      attr_reader :id, :list_after_id, :table, :path
+
+      def initialize(id, list_after_id, opts={})
+        @id = id
+        @list_after_id = list_after_id
+        @table = opts.fetch(:table, DEFAULT_TABLE)
+        @path = opts.fetch(:path, DEFAULT_PATH)
+      end
+
+      def commands
+        [
+          Commands::Factory.build(
+            COMMAND_TYPE,
+            id,
+            args: args,
+            table: table,
+            path: path
+          )
+        ]
+      end
+
+      def args
+        {
+          id: list_after_id
+        }
+      end
+    end
+  end
+end

--- a/lib/notion_rb/operations/set_block_created_time.rb
+++ b/lib/notion_rb/operations/set_block_created_time.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module NotionRb
+  module Operations
+    class SetBlockCreatedTime < SetBlockLastEditedTime
+      OPERATION_NAME = :set_block_created_time
+      DEFAULT_PATH = ['created_time'].freeze
+
+      def initialize(id, time, opts = {})
+        opts[:path] ||= DEFAULT_PATH
+        super
+      end
+    end
+  end
+end

--- a/lib/notion_rb/operations/set_block_last_edited_time.rb
+++ b/lib/notion_rb/operations/set_block_last_edited_time.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module NotionRb
+  module Operations
+    class SetBlockLastEditedTime
+      COMMAND_TYPE = :set
+      OPERATION_NAME = :set_block_last_edited_time
+      DEFAULT_PATH = ['last_edited_time'].freeze
+      TABLE = 'block'
+
+      attr_reader :id, :time, :path
+
+      def initialize(id, time, opts = {})
+        @id = id
+        @time = time
+        @path = opts.fetch(:path, DEFAULT_PATH)
+      end
+
+      def commands
+        [
+          Commands::Factory.build(
+            COMMAND_TYPE,
+            id,
+            args: args,
+            table: TABLE,
+            path: path
+          )
+        ]
+      end
+
+      def args
+        time
+      end
+    end
+  end
+end

--- a/lib/notion_rb/operations/set_block_title.rb
+++ b/lib/notion_rb/operations/set_block_title.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module NotionRb
+  module Operations
+    class SetBlockTitle
+      COMMAND_TYPE = :set
+      OPERATION_NAME = :set_block_title
+      TABLE = 'block'
+      DEFAULT_PATH = %w[properties title].freeze
+
+      attr_reader :id, :title, :path
+
+      def initialize(id, title = nil, opts = {})
+        @id = id
+        @title = title
+        @path = opts.fetch(:path, DEFAULT_PATH)
+      end
+
+      def commands
+        [
+          Commands::Factory.build(
+            COMMAND_TYPE,
+            id,
+            args: args,
+            table: TABLE,
+            path: path
+          )
+        ]
+      end
+
+      def args
+        return [] if title.nil?
+      end
+    end
+  end
+end

--- a/lib/notion_rb/operations/set_block_type.rb
+++ b/lib/notion_rb/operations/set_block_type.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module NotionRb
+  module Operations
+    class SetBlockType
+      DEFAULT_VERSION = 1
+      COMMAND_TYPE = :set
+      OPERATION_NAME = :set_block_type
+      TABLE = 'block'
+
+      attr_reader :id, :type
+
+      def initialize(id, type)
+        @id = id
+        @type = type
+      end
+
+      def commands
+        [
+          Commands::Factory.build(
+            :set,
+            id,
+            args: args,
+            table: TABLE
+          )
+        ]
+      end
+
+      def args
+        {
+          type: type,
+          version: DEFAULT_VERSION,
+          id: id
+        }
+      end
+    end
+  end
+end

--- a/lib/notion_rb/operations/update_parent.rb
+++ b/lib/notion_rb/operations/update_parent.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+module NotionRb
+  module Operations
+    class UpdateParent
+      COMMAND_TYPE = :update
+      OPERATION_NAME = :update_parent
+      TABLE = 'block'
+      DEFAULT_PARENT_TABLE = TABLE
+      DEFAULT_ALIVE_VALUE = true
+
+      attr_reader :id, :parent_id, :parent_table, :alive
+
+      def initialize(id, parent_id, opts = {})
+        @id = id
+        @parent_id = parent_id
+        @parent_table = opts.fetch(:parent_table, DEFAULT_PARENT_TABLE)
+        @alive = opts.fetch(:alive, DEFAULT_ALIVE_VALUE)
+      end
+
+      def commands
+        [
+          Commands::Factory.build(
+            COMMAND_TYPE,
+            id,
+            args: args,
+            table: TABLE
+          )
+        ]
+      end
+
+      def args
+        {
+          parent_id: parent_id,
+          parent_table: parent_table,
+          alive: alive
+        }
+      end
+    end
+  end
+end

--- a/lib/notion_rb/request_params.rb
+++ b/lib/notion_rb/request_params.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module NotionRb
+  class RequestParams
+    attr_reader :transactions, :request_id
+
+    def initialize
+      @request_id = SecureRandom.uuid
+      @transactions = []
+    end
+
+    def add_transaction
+      Transaction.new.tap { |t| @transactions.push(t) }
+    end
+
+    def to_h
+      {
+        requestId: request_id,
+        transactions: transactions.map(&:to_h)
+      }
+    end
+  end
+end

--- a/lib/notion_rb/transaction.rb
+++ b/lib/notion_rb/transaction.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module NotionRb
+  class Transaction
+    attr_reader :id, :operations
+
+    def initialize
+      @id = SecureRandom.uuid
+      @operations = []
+    end
+
+    def add_operation(operation_name, *args)
+      operations.push(
+        Operations::Factory.build(operation_name, *args)
+      )
+      self
+    end
+
+    def to_h
+      { id: id, operations: operations.flat_map { |o| o.commands.map(&:to_h) } }
+    end
+  end
+end

--- a/spec/notion_rb/operations/commands/base_spec.rb
+++ b/spec/notion_rb/operations/commands/base_spec.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+require 'notion_rb/operations/commands/base'
+SingleCov.covered!
+
+module NotionRb::Operations::Commands
+  RSpec.describe Base do
+    let(:id) { '8de6cf7c-2cbd-40e6-9ee0-6a139ffa1523' }
+    let(:command) { 'sample-command' }
+    let(:opts) { { command: command } }
+    let(:table) { 'block' }
+    let(:args) { 'args' }
+    let(:path) { 'path' }
+    subject(:instance) { described_class.new(id, opts) }
+
+    context 'when initialized with an id and opts hash' do
+      context 'and opts hash does not have a :command key' do
+        let(:opts) { {} }
+
+        it 'raises an ArgumentError' do
+          expect { instance }.to raise_error ArgumentError
+        end
+      end
+
+      context 'and the opts hash commands a command key' do
+        it 'sets the command and id properly' do
+          expect(instance.id).to eq id
+          expect(instance.command).to eq command
+        end
+      end
+
+      context 'and opts contanins other valid keys' do
+        let(:opts) do
+          {
+            command: command,
+            table: table,
+            path: path,
+            args: args
+          }
+        end
+
+        it 'sets those attributes properly' do
+          expect(instance.table).to eq table
+          expect(instance.args).to eq args
+          expect(instance.path).to eq path
+        end
+      end
+    end
+
+    describe '#to_h' do
+      subject { instance.to_h }
+      let(:opts) do
+        {
+          command: command,
+          table: table,
+          path: path,
+          args: args
+        }
+      end
+
+      it 'returns the attributes of the command as a serializable hash' do
+        is_expected.to match(
+          id: id,
+          table: table,
+          path: path,
+          command: command,
+          args: args
+        )
+      end
+    end
+  end
+end

--- a/spec/notion_rb/operations/commands/factory_spec.rb
+++ b/spec/notion_rb/operations/commands/factory_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+SingleCov.covered!
+
+module NotionRb::Operations::Commands
+  RSpec.describe Factory do
+    subject(:instance) { described_class.new }
+
+    describe '.build' do
+      context 'when passed a command name, primary notion id, and opts args' do
+        subject { described_class.build(command_name, notion_id, opts) }
+        let(:notion_id) { 'id-1' }
+        let(:opts) { {} }
+
+        context 'and the command name is valid' do
+          let(:command_name) { :set }
+
+          it 'initializes the proper command with the args' do
+            expect(Set).to receive(:new).with(notion_id, {})
+            subject
+          end
+        end
+
+        context 'and the command name is not valid' do
+          let(:command_name) { :cat }
+
+          it 'raises a KeyError' do
+            expect { subject }.to raise_error(KeyError)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/notion_rb/operations/commands/list_after_spec.rb
+++ b/spec/notion_rb/operations/commands/list_after_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+require 'notion_rb/operations/commands/list_after'
+SingleCov.covered!
+
+module NotionRb::Operations::Commands
+  RSpec.describe ListAfter do
+    let(:id) { '8d2d966c-12b1-45e7-a975-771f0bb13288' }
+    let(:opts) { {} }
+    subject(:instance) { described_class.new(id, opts) }
+
+    it_behaves_like 'a command object'
+  end
+end

--- a/spec/notion_rb/operations/commands/set_spec.rb
+++ b/spec/notion_rb/operations/commands/set_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+require 'notion_rb/operations/commands/set'
+SingleCov.covered!
+
+module NotionRb::Operations::Commands
+  RSpec.describe Set do
+    let(:id) { '8d2d966c-12b1-45e7-a975-771f0bb13288' }
+    let(:opts) { {} }
+    subject(:instance) { described_class.new(id, opts) }
+
+    it_behaves_like 'a command object'
+  end
+end

--- a/spec/notion_rb/operations/commands/update_spec.rb
+++ b/spec/notion_rb/operations/commands/update_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+require 'notion_rb/operations/commands/update'
+SingleCov.covered!
+
+module NotionRb::Operations::Commands
+  RSpec.describe Update do
+    let(:id) { '8d2d966c-12b1-45e7-a975-771f0bb13288' }
+    let(:opts) { {} }
+    subject(:instance) { described_class.new(id, opts) }
+
+    it_behaves_like 'a command object'
+  end
+end

--- a/spec/notion_rb/operations/factory_spec.rb
+++ b/spec/notion_rb/operations/factory_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+SingleCov.covered!
+
+module NotionRb::Operations
+  RSpec.describe Factory do
+    subject(:instance) { described_class.new }
+
+    describe '.build' do
+      context 'when passed an operation name and operation args' do
+        let(:args) { [] }
+        subject { described_class.build(operation_name, *args) }
+        context 'and the operation name is valid' do
+          let(:operation_name) { :list_after }
+          let(:args) { ['id-1', 'id-2'] }
+
+          it 'initializes the proper operation with the args' do
+            expect(ListAfter).to receive(:new).with(*args)
+            subject
+          end
+        end
+
+        context 'and the operation name is not valid' do
+          let(:operation_name) { :cat }
+
+          it 'raises a KeyError' do
+            expect { subject }.to raise_error(KeyError)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/notion_rb/operations/list_after_spec.rb
+++ b/spec/notion_rb/operations/list_after_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'notion_rb/operations/list_after'
+SingleCov.covered!
+
+module NotionRb::Operations
+  RSpec.describe ListAfter do
+    let(:id) { 'cb71f959-2f27-4756-a5d2-59b355cebef5' }
+    let(:list_after_id) { '09ff327d-885e-4320-bc86-a2e19700ed23' }
+    let(:opts) { {} }
+
+    subject(:instance) { described_class.new(id, list_after_id, opts) }
+
+    it_behaves_like 'an operation object'
+  end
+end

--- a/spec/notion_rb/operations/set_block_created_time_spec.rb
+++ b/spec/notion_rb/operations/set_block_created_time_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'notion_rb/operations/set_block_created_time_spec'
+SingleCov.covered!
+
+module NotionRb::Operations
+  RSpec.describe ListAfter do
+    let(:id) { 'cb71f959-2f27-4756-a5d2-59b355cebef5' }
+    let(:time) { DateTime.new }
+    let(:opts) { {} }
+
+    subject(:instance) { described_class.new(id, time, opts) }
+
+    it_behaves_like 'an operation object'
+  end
+end

--- a/spec/notion_rb/operations/set_block_last_edited_time_spec.rb
+++ b/spec/notion_rb/operations/set_block_last_edited_time_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'notion_rb/operations/set_block_last_edited_time'
+SingleCov.covered!
+
+module NotionRb::Operations
+  RSpec.describe SetBlockLastEditedTime do
+    let(:id) { 'cb71f959-2f27-4756-a5d2-59b355cebef5' }
+    let(:time) { DateTime.new }
+    let(:opts) { {} }
+
+    subject(:instance) { described_class.new(id, time, opts) }
+
+    it_behaves_like 'an operation object'
+  end
+end

--- a/spec/notion_rb/operations/set_block_title_spec.rb
+++ b/spec/notion_rb/operations/set_block_title_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'notion_rb/operations/set_block_title'
+SingleCov.covered!
+
+module NotionRb::Operations
+  RSpec.describe SetBlockTitle do
+    let(:id) { 'cb71f959-2f27-4756-a5d2-59b355cebef5' }
+    let(:title) { 'new title' }
+    let(:opts) { {} }
+
+    subject(:instance) { described_class.new(id, title, opts) }
+
+    it_behaves_like 'an operation object'
+  end
+end

--- a/spec/notion_rb/operations/set_block_type_spec.rb
+++ b/spec/notion_rb/operations/set_block_type_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require 'notion_rb/operations/set_block_type'
+SingleCov.covered!
+
+module NotionRb::Operations
+  RSpec.describe SetBlockType do
+    let(:id) { 'cb71f959-2f27-4756-a5d2-59b355cebef5' }
+    let(:type) { 'block' }
+
+    subject(:instance) { described_class.new(id, type) }
+
+    it_behaves_like 'an operation object'
+  end
+end

--- a/spec/notion_rb/operations/update_parent_spec.rb
+++ b/spec/notion_rb/operations/update_parent_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'notion_rb/operations/update_parent'
+SingleCov.covered!
+
+module NotionRb::Operations
+  RSpec.describe UpdateParent do
+    let(:id) { 'cb71f959-2f27-4756-a5d2-59b355cebef5' }
+    let(:parent_id) { '182125b2-b602-48fc-840d-ef191fd5d93d' }
+    let(:opts) { {} }
+
+    subject(:instance) { described_class.new(id, parent_id, opts) }
+
+    it_behaves_like 'an operation object'
+  end
+end

--- a/spec/notion_rb/request_params_spec.rb
+++ b/spec/notion_rb/request_params_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+SingleCov.covered!
+
+module NotionRb
+  RSpec.describe RequestParams do
+    subject(:instance) { described_class.new }
+
+    describe '#add_transaction' do
+      subject { instance.add_transaction }
+
+      it { is_expected.to be_a Transaction }
+
+      it 'adds the returned transaction to its transactions' do
+        expect { subject }
+          .to change(instance.transactions, :count).by(1)
+
+        expect(instance.transactions).to include(subject)
+      end
+    end
+
+    describe '#to_h' do
+      subject { instance.to_h }
+
+      let(:t_as_h) { { a: :b } }
+      let(:t2_as_h) { { a: :c } }
+      let(:transaction) { double('transaction', to_h: t_as_h) }
+      let(:transaction_2) { double('transaction', to_h: t2_as_h) }
+
+      before do
+        expect(Transaction).to receive(:new).and_return(transaction)
+        expect(Transaction).to receive(:new).and_return(transaction_2)
+        2.times { instance.add_transaction }
+      end
+
+      it 'returns a hash containing its request_id and transactions' do
+        is_expected.to match(
+          requestId: a_string_matching(/[a-f0-9\-]*/),
+          transactions: [t_as_h, t2_as_h]
+        )
+      end
+    end
+  end
+end

--- a/spec/notion_rb/transaction_spec.rb
+++ b/spec/notion_rb/transaction_spec.rb
@@ -11,8 +11,17 @@ module NotionRb
 
       context 'with operations added' do
         let(:block_id) { '1234556' }
+        let(:parent_id) { '789' }
+        let(:created_time) { (Time.now.to_i / 100) * 100_000 }
         before do
           instance.add_operation(:set_block_type, block_id, 'text')
+          instance.add_operation(:update_parent, block_id, parent_id)
+          instance.add_operation(:list_after, parent_id, block_id)
+          instance.add_operation(:set_block_title, block_id)
+          instance.add_operation(:set_block_created_time, block_id,
+                                 created_time)
+          instance.add_operation(:set_block_last_edited_time, block_id,
+                                 created_time)
         end
 
         it 'returns the transaction as a hash for execution' do
@@ -25,6 +34,41 @@ module NotionRb
                 path: [],
                 command: 'set',
                 args: { type: 'text', id: block_id, version: 1 }
+              },
+              {
+                id: block_id,
+                table: 'block',
+                path: [],
+                command: 'update',
+                args: { parent_id: parent_id, parent_table: 'block',
+                        alive: true }
+              }, {
+                id: parent_id,
+                table: 'block',
+                path: ['content'],
+                command: 'listAfter',
+                args: { id: block_id }
+              }, {
+                id: block_id,
+                table: 'block',
+                path: %w[
+                  properties
+                  title
+                ],
+                command: 'set',
+                args: []
+              }, {
+                id: block_id,
+                table: 'block',
+                path: ['created_time'],
+                command: 'set',
+                args: created_time
+              }, {
+                id: block_id,
+                table: 'block',
+                path: ['last_edited_time'],
+                command: 'set',
+                args: created_time
               }
             ]
           )

--- a/spec/notion_rb/transaction_spec.rb
+++ b/spec/notion_rb/transaction_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+SingleCov.covered!
+
+module NotionRb
+  RSpec.describe Transaction do
+    subject(:instance) { described_class.new }
+
+    describe '#to_h' do
+      subject { instance.to_h }
+
+      context 'with operations added' do
+        let(:block_id) { '1234556' }
+        before do
+          instance.add_operation(:set_block_type, block_id, 'text')
+        end
+
+        it 'returns the transaction as a hash for execution' do
+          is_expected.to match(
+            id: a_string_matching(/[a-f0-9\-]*/),
+            operations: [
+              {
+                id: block_id,
+                table: 'block',
+                path: [],
+                command: 'set',
+                args: { type: 'text', id: block_id, version: 1 }
+              }
+            ]
+          )
+        end
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,6 +9,8 @@ require 'byebug'
 require 'factory_bot'
 require 'vcr'
 
+Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].each { |f| require f }
+
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure
   config.example_status_persistence_file_path = '.rspec_status'

--- a/spec/support/shared_examples/command_object.rb
+++ b/spec/support/shared_examples/command_object.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples 'a command object' do
+  let(:id) { '4461b1c2-dac2-4908-bb17-cb7c02133067' }
+  let(:command_key) { 'set' }
+  let(:opts) { { command: command_key } }
+
+  subject(:instance) { described_class.new(id, opts) }
+
+  describe '#to_h' do
+    subject { instance.to_h }
+
+    it 'returns a hash containing the id and the correct command' do
+      is_expected.to be_a Hash
+      expect(subject[:id]).to eq id
+      expect(subject[:command]).to eq described_class::COMMAND
+    end
+  end
+end

--- a/spec/support/shared_examples/operation_object.rb
+++ b/spec/support/shared_examples/operation_object.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples 'an operation object' do
+  describe '#commands' do
+    subject { instance.commands }
+
+    it 'returns an array of command objects' do
+      is_expected.to be_an Array
+      is_expected.not_to be_empty
+      is_expected.to all(be_a NotionRb::Operations::Commands::Base)
+    end
+  end
+end


### PR DESCRIPTION
Hi Tomás,

I wanted to get your thoughts on this approach to building the operation params. It seems the notion API uses a smaller set of command operations to build up to a transaction which then get combined into the request params. This PR creates these small commands as independent object/classes which can then be built up to make the request params in higher level actions such as Creating an empty block. The key part of this PR can be seen here: 

https://github.com/tpgunther/notion_rb/compare/master...mcordell:Refactor-Operation-Building?expand=1#diff-f72fdbed1ac13d69ac4b4a54d98c73ba


Thanks
